### PR TITLE
use of decodeURI() vs decodeURIComponent()

### DIFF
--- a/index.next.js
+++ b/index.next.js
@@ -106,7 +106,7 @@ export const toURL = (path, pathRegExp, options = {}) => {
   // extend the url object adding the matched params
   url.params = params.reduce((acc, param, index) => {
     const key = options.keys && options.keys[index]
-    if (key) acc[key.name] = param
+    if (key) acc[key.name] = decodeURIComponent(param)
     return acc
   }, {})
 
@@ -129,7 +129,7 @@ export const match = (path, pathRegExp) => pathRegExp.test(path)
  * @returns {Array} a functions array that will be used as stream pipe for erre.js
  */
 export const createURLStreamPipe = (pathRegExp, options) => [
-  decodeURIComponent,
+  decodeURI,
   replaceBase,
   matchOrSkip(pathRegExp, options),
   path => toURL(path, pathRegExp, options)

--- a/test.js
+++ b/test.js
@@ -99,13 +99,13 @@ describe('rawth', function() {
     fooBarStream.off.value(fail)
   })
 
-  it('encoded strings will be decoded with decodeURIComponent', done => {
+  it('encoded URIs will be decoded with decodeURI', done => {
     const fooBarStream = route(':foo/:bar\\?(.*)')
 
     fooBarStream.on.value((path) => {
       expect(path.params.foo).to.be.equal('foo')
-      expect(path.params.bar).to.be.equal('bar')
-      expect(path.query).to.be.equal('x=test')
+      expect(path.params.bar).to.be.equal('ba r')
+      expect(path.query).to.be.equal('x=test&y=é')
 
       fooBarStream.end()
 
@@ -114,7 +114,27 @@ describe('rawth', function() {
       return erre.off()
     })
 
-    router.push('foo/bar%3Fx%3Dtest')
+    router.push('foo/ba%20r?x=test&y=%C3%A9')
+  })
+
+  it('encoded path elements (but NOT query) will be decoded with decodeURIComponent', done => {
+    const fooBarStream = route(':foo/:bar\\?(.*)')
+
+    fooBarStream.on.value((path) => {
+      expect(path.params.foo).to.be.equal('foo;v=1')
+      expect(path.params.bar).to.be.equal('ba&r')
+      // NOTE: decodeURIComponent() would also decode component separators such as /, ?, &
+      // reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI
+      expect(path.query).to.be.equal('y=%26&z=end')  // %26 is &
+
+      fooBarStream.end()
+
+      done()
+
+      return erre.off()
+    })
+
+    router.push('foo;v=1/ba%26r?y=%26&z=end')
   })
 
   it('bypass router arguments different from strings', (done) => ((count = 0) => {


### PR DESCRIPTION
As requested in [riot PR-158](https://github.com/riot/route/pull/158) this is a proposal to replace use of `decodeURIComponent()` by `decodeURI()`... or actually use a bit of both as you will see:
* `decodeURI()` is used for the full path / URI (this was the fix originally intented)
* `decodeURIComponent()` is used for individual path elements (`decodeURI()` by itself is not enough, see [this warning](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI))

Goal is to decode as much as possible with `rawth`. Individual elements of the query string however remains encoded, since `rawth` currently does not parse / unmarshal the content of the query string.

I made sure to add a test, which fails if only `decodeURIComponent()` is used like is currently the case.