### PR TITLE
Fix regression for empty optional parameters

### DIFF
--- a/index.next.js
+++ b/index.next.js
@@ -106,7 +106,7 @@ export const toURL = (path, pathRegExp, options = {}) => {
   // extend the url object adding the matched params
   url.params = params.reduce((acc, param, index) => {
     const key = options.keys && options.keys[index]
-    if (key) acc[key.name] = param
+    if (key) acc[key.name] = decodeURIComponent(param)
     return acc
   }, {})
 
@@ -129,7 +129,7 @@ export const match = (path, pathRegExp) => pathRegExp.test(path)
  * @returns {Array} a functions array that will be used as stream pipe for erre.js
  */
 export const createURLStreamPipe = (pathRegExp, options) => [
-  decodeURIComponent,
+  decodeURI,
   replaceBase,
   matchOrSkip(pathRegExp, options),
   path => toURL(path, pathRegExp, options)

--- a/index.next.js
+++ b/index.next.js
@@ -106,7 +106,7 @@ export const toURL = (path, pathRegExp, options = {}) => {
   // extend the url object adding the matched params
   url.params = params.reduce((acc, param, index) => {
     const key = options.keys && options.keys[index]
-    if (key) acc[key.name] = decodeURIComponent(param)
+    if (key) acc[key.name] = param ? decodeURIComponent(param) : param
     return acc
   }, {})
 

--- a/test.js
+++ b/test.js
@@ -99,13 +99,13 @@ describe('rawth', function() {
     fooBarStream.off.value(fail)
   })
 
-  it('encoded strings will be decoded with decodeURIComponent', done => {
+  it('encoded URIs will be decoded with decodeURI', done => {
     const fooBarStream = route(':foo/:bar\\?(.*)')
 
     fooBarStream.on.value((path) => {
       expect(path.params.foo).to.be.equal('foo')
-      expect(path.params.bar).to.be.equal('bar')
-      expect(path.query).to.be.equal('x=test')
+      expect(path.params.bar).to.be.equal('ba r')
+      expect(path.query).to.be.equal('x=test&y=é')
 
       fooBarStream.end()
 
@@ -114,7 +114,27 @@ describe('rawth', function() {
       return erre.off()
     })
 
-    router.push('foo/bar%3Fx%3Dtest')
+    router.push('foo/ba%20r?x=test&y=%C3%A9')
+  })
+
+  it('encoded path elements (but NOT query) will be decoded with decodeURIComponent', done => {
+    const fooBarStream = route(':foo/:bar\\?(.*)')
+
+    fooBarStream.on.value((path) => {
+      expect(path.params.foo).to.be.equal('foo;v=1')
+      expect(path.params.bar).to.be.equal('ba&r')
+      // NOTE: decodeURIComponent() would also decode component separators such as /, ?, &
+      // reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI
+      expect(path.query).to.be.equal('y=%26&z=end')  // %26 is &
+
+      fooBarStream.end()
+
+      done()
+
+      return erre.off()
+    })
+
+    router.push('foo;v=1/ba%26r?y=%26&z=end')
   })
 
   it('bypass router arguments different from strings', (done) => ((count = 0) => {

--- a/test.js
+++ b/test.js
@@ -43,6 +43,15 @@ describe('rawth', function() {
     expect(url.params.bar).to.be.equal('bar')
   })
 
+  it('the toURL method will provide undefined for empty optional parameters', () => {
+    const keys = []
+    const path = toRegexp(':foo?/:bar?', keys)
+    const url = toURL('foo', path, {keys})
+
+    expect(url.params.foo).to.be.equal('foo')
+    expect(url.params.bar).to.be.equal(undefined)
+  })
+
   it('the match method will return true only for the routes matching the test regex', () => {
     const path = toRegexp('/:foo/:bar')
 


### PR DESCRIPTION
I am sorry @GianlucaGuarini, I managed to introduce a regression in [PR-5](https://github.com/GianlucaGuarini/rawth/pull/5):
optional parameters such as `/:foo?` are delivered as `undefined` when empty but the new call to `decodeURIComponent()` turned that value into a string `'undefined'`. This is now fixed and I added a test for optional parameters.